### PR TITLE
check map is defined

### DIFF
--- a/interaction/selectclusterinteraction.js
+++ b/interaction/selectclusterinteraction.js
@@ -100,7 +100,7 @@ ol.interaction.SelectCluster.prototype.setMap = function(map)
 {	ol.interaction.Select.prototype.setMap.call (this, map);
 	var self = this;
 
-	if (this.map_ && this.map_.getView()) 
+	if (map && this.map_ && this.map_.getView()) 
 	{	map.getView().un('change:resolution', this.clear, this);
 	}
 	if (this.map_) this.map_.removeLayer(this.overlayLayer_);


### PR DESCRIPTION
When you set selectSpread as false after creating the layer, you'll remove `ol.interaction.SelectCluster` from `map.interactions`. but then OL does `interaction.setMap(null)` so the code occurs the error `Uncaught TypeError: Cannot read property 'getView' of null`. should check `map` is defined before getting `getView()`